### PR TITLE
GraphQLスキーマにPhotoTypeを追加

### DIFF
--- a/rails/app/graphql/types/photo_category_type.rb
+++ b/rails/app/graphql/types/photo_category_type.rb
@@ -2,12 +2,12 @@
 
 module Types
   class PhotoCategoryType < Types::BaseEnum
-    description 'Category of the photo'
+    description "Category of the photo"
 
-    value 'SELFIE', 'A photo taken of oneself', value: :selfie
-    value 'PORTRAIT', 'A portrait photo', value: :portrait
-    value 'ACTION', 'An action photo', value: :action
-    value 'LANDSCAPE', 'A landscape photo', value: :landscape
-    value 'GRAPHIC', 'A graphic photo', value: :graphic
+    value "SELFIE", "A photo taken of oneself", value: :selfie
+    value "PORTRAIT", "A portrait photo", value: :portrait
+    value "ACTION", "An action photo", value: :action
+    value "LANDSCAPE", "A landscape photo", value: :landscape
+    value "GRAPHIC", "A graphic photo", value: :graphic
   end
 end

--- a/rails/app/graphql/types/photo_category_type.rb
+++ b/rails/app/graphql/types/photo_category_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  class PhotoCategoryType < Types::BaseEnum
+    description 'Category of the photo'
+
+    value 'SELFIE', 'A photo taken of oneself', value: :selfie
+    value 'PORTRAIT', 'A portrait photo', value: :portrait
+    value 'ACTION', 'An action photo', value: :action
+    value 'LANDSCAPE', 'A landscape photo', value: :landscape
+    value 'GRAPHIC', 'A graphic photo', value: :graphic
+  end
+end

--- a/rails/app/graphql/types/photo_type.rb
+++ b/rails/app/graphql/types/photo_type.rb
@@ -3,9 +3,9 @@
 module Types
   class PhotoType < Types::BaseObject
     field :id, ID, null: false
-    field :name, String, 'The name of the photo', null: false
-    field :category, Types::PhotoCategoryType, 'The category of the photo'
-    field :url, String, 'The URL of the photo', null: false
+    field :name, String, "The name of the photo", null: false
+    field :category, Types::PhotoCategoryType, "The category of the photo"
+    field :url, String, "The URL of the photo", null: false
     field :description, String
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/rails/app/graphql/types/photo_type.rb
+++ b/rails/app/graphql/types/photo_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  class PhotoType < Types::BaseObject
+    field :id, ID, null: false
+    field :name, String
+    field :url, String
+    field :description, String
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/rails/app/graphql/types/photo_type.rb
+++ b/rails/app/graphql/types/photo_type.rb
@@ -3,8 +3,9 @@
 module Types
   class PhotoType < Types::BaseObject
     field :id, ID, null: false
-    field :name, String
-    field :url, String
+    field :name, String, 'The name of the photo', null: false
+    field :category, Types::PhotoCategoryType, 'The category of the photo'
+    field :url, String, 'The URL of the photo', null: false
     field :description, String
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/rails/app/models/photo.rb
+++ b/rails/app/models/photo.rb
@@ -1,0 +1,2 @@
+class Photo < ApplicationRecord
+end

--- a/rails/app/models/photo.rb
+++ b/rails/app/models/photo.rb
@@ -1,2 +1,4 @@
 class Photo < ApplicationRecord
+  validates :name, presence: true
+  validates :url, presence: true
 end

--- a/rails/db/migrate/20250213231552_create_photos.rb
+++ b/rails/db/migrate/20250213231552_create_photos.rb
@@ -1,8 +1,8 @@
 class CreatePhotos < ActiveRecord::Migration[7.0]
   def change
     create_table :photos do |t|
-      t.string :name
-      t.string :url
+      t.string :name, null: false
+      t.string :url, null: false
       t.string :description
 
       t.timestamps

--- a/rails/db/migrate/20250213231552_create_photos.rb
+++ b/rails/db/migrate/20250213231552_create_photos.rb
@@ -1,0 +1,11 @@
+class CreatePhotos < ActiveRecord::Migration[7.0]
+  def change
+    create_table :photos do |t|
+      t.string :name
+      t.string :url
+      t.string :description
+
+      t.timestamps
+    end
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -12,8 +12,8 @@
 
 ActiveRecord::Schema[7.0].define(version: 2025_02_13_231552) do
   create_table "photos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "name"
-    t.string "url"
+    t.string "name", null: false
+    t.string "url", null: false
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -1,0 +1,22 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2025_02_13_231552) do
+  create_table "photos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
+    t.string "url"
+    t.string "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end


### PR DESCRIPTION
## 概要
このPRでは、GraphQLスキーマに新しいPhotoTypeを追加しました。これにより、写真に関する情報をGraphQLクエリで取得できるようになります。

## 変更内容
Types::PhotoTypeクラスを追加
id: ID型、null不可
name: String型、null不可、写真の名前
category: Types::PhotoCategoryType型、写真のカテゴリ
url: String型、null不可、写真のURL
description: String型、写真の説明
created_at: GraphQL::Types::ISO8601DateTime型、null不可、作成日時
updated_at: GraphQL::Types::ISO8601DateTime型、null不可、更新日時
