### PR TITLE
ユーザーモデルを追加して写真と関連付ける

### DIFF
--- a/rails/app/models/photo.rb
+++ b/rails/app/models/photo.rb
@@ -1,4 +1,5 @@
 class Photo < ApplicationRecord
+  belongs_to :user
   validates :name, presence: true
   validates :url, presence: true
   enum category: { selfie: 0, portrait: 1, action: 2, landscape: 3, graphic: 4 }

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -1,0 +1,4 @@
+class User < ApplicationRecord
+  has_many :photos, dependent: :destroy
+  validates :github_login, presence: true, uniqueness: true
+end

--- a/rails/db/migrate/20250215001128_create_users.rb
+++ b/rails/db/migrate/20250215001128_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      t.string :github_login, null: false
+      t.string :name
+      t.string :avatar
+
+      t.timestamps
+    end
+    add_index :users, :github_login, unique: true
+  end
+end

--- a/rails/db/migrate/20250215010501_add_user_ref_to_photos.rb
+++ b/rails/db/migrate/20250215010501_add_user_ref_to_photos.rb
@@ -1,0 +1,9 @@
+class AddUserRefToPhotos < ActiveRecord::Migration[7.0]
+  def up
+    add_reference :photos, :user, null: false, foreign_key: true
+  end
+
+  def down
+    remove_reference :photos, :user, foreign_key: true
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_02_14_050200) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_15_010501) do
   create_table "photos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "url", null: false
@@ -18,6 +18,18 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_14_050200) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "category"
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_photos_on_user_id"
   end
 
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "github_login", null: false
+    t.string "name"
+    t.string "avatar"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["github_login"], name: "index_users_on_github_login", unique: true
+  end
+
+  add_foreign_key "photos", "users"
 end


### PR DESCRIPTION
- GitHubログインバリデーションでUserモデルを作成する
- User と Photos の間に一対多のリレーションを追加する
- スキーマを更新して photos テーブルに user_id を追加し、users テーブルを作成する
- photos テーブルに user_id の外部キー制約を追加する