### PR TITLE
User typeの追加

### DIFF
--- a/rails/app/graphql/types/photo_type.rb
+++ b/rails/app/graphql/types/photo_type.rb
@@ -8,6 +8,5 @@ module Types
     field :url, String, "The URL of the photo", null: false
     field :description, String
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
-    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
   end
 end

--- a/rails/app/graphql/types/photo_type.rb
+++ b/rails/app/graphql/types/photo_type.rb
@@ -8,5 +8,6 @@ module Types
     field :url, String, "The URL of the photo", null: false
     field :description, String
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :posted_by, Types::UserType, "The user who posted the photo", null: false
   end
 end

--- a/rails/app/graphql/types/user_type.rb
+++ b/rails/app/graphql/types/user_type.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  class UserType < Types::BaseObject
+    field :id, ID, null: false
+    field :github_login, String, null: false
+    field :name, String
+    field :avatar, String
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/rails/app/graphql/types/user_type.rb
+++ b/rails/app/graphql/types/user_type.rb
@@ -6,6 +6,6 @@ module Types
     field :github_login, String, null: false
     field :name, String
     field :avatar, String
-    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :posted_photos, [Types::PhotoType]
   end
 end


### PR DESCRIPTION
- PhotoType に `posted_by` フィールドを追加し、写真を投稿したユーザを表示する。
- UserType の `created_at` フィールドを `posted_photos` フィールドに置き換えて、ユーザと写真の関係を確立する