### PR TITLE
合計ユーザー数と写真数のリゾルバをGraphQLスキーマに追加

### DIFF
--- a/rails/app/graphql/resolvers/total_photos.rb
+++ b/rails/app/graphql/resolvers/total_photos.rb
@@ -7,4 +7,3 @@ module Resolvers
     end
   end
 end
-  

--- a/rails/app/graphql/resolvers/total_photos.rb
+++ b/rails/app/graphql/resolvers/total_photos.rb
@@ -1,0 +1,10 @@
+module Resolvers
+  class TotalPhotos < BaseResolver
+    type Integer, null: false
+
+    def resolve
+      ::Photo.count
+    end
+  end
+end
+  

--- a/rails/app/graphql/resolvers/total_users.rb
+++ b/rails/app/graphql/resolvers/total_users.rb
@@ -1,0 +1,9 @@
+module Resolvers
+  class TotalUsers < BaseResolver
+    type Integer, null: false
+
+    def resolve
+      ::User.count
+    end
+  end
+end

--- a/rails/app/graphql/types/query_type.rb
+++ b/rails/app/graphql/types/query_type.rb
@@ -23,7 +23,9 @@ module Types
 
     field :photo, resolver: Resolvers::Photo
     field :photos, resolver: Resolvers::Photos
+    field :total_photos, resolver: Resolvers::TotalPhotos
     field :user, resolver: Resolvers::User
     field :users, resolver: Resolvers::Users
+    field :total_users, resolver: Resolvers::TotalUsers
   end
 end


### PR DESCRIPTION
- TotalUsersとTotalPhotosリゾルバを作成し、ユーザーと写真の総カウントを取得する
- QueryTypeに対応するフィールドを追加し、GraphQL経由で総カウント数を取得する