### PR TITLE
AllPhotosリゾルバをカテゴリでフィルタリングできるようにする

### DIFF
--- a/rails/app/graphql/resolvers/all_photos.rb
+++ b/rails/app/graphql/resolvers/all_photos.rb
@@ -1,10 +1,15 @@
 module Resolvers
   class AllPhotos < BaseResolver
     description "Find all photos"
-    type [Types::PhotoType], null: true
+    type [Types::PhotoType], null: false
 
-    def resolve
-      ::Photo.all
+    argument :category, Types::PhotoCategoryType, required: false
+
+    def resolve(category: nil)
+      photos = ::Photo.all
+      return photos if category.nil?
+
+      photos.where(category: category)
     end
   end
 end


### PR DESCRIPTION
- AllPhotosリゾルバにオプションのカテゴリー引数を追加
- resolveメソッドを修正し、指定された場合にカテゴリで写真をフィルタリングするようにしました。
- 写真リストの戻り値の型をnull型からnull不可型に変更