### PR TITLE
postPhotoミューテーションの修正

### DIFF
--- a/rails/app/graphql/mutations/post_photo.rb
+++ b/rails/app/graphql/mutations/post_photo.rb
@@ -7,10 +7,14 @@ module Mutations
     argument :category, Types::PhotoCategory, required: false, default_value: "portrait"
 
     def resolve(**args)
-      photo = Photo.create!(**args.merge(user: User.first, url: "pending"))
-      photo.update!(url: "https://example.com/photos/#{photo.id}.jpg")
+      user = context[:current_user]
+      raise GraphQL::ExecutionError, "Only an authorized user can post a photo" if user.nil?
+
+      photo = user.photos.create!(**args, url: "pending")
+      photo.update!(url: "/img/photos/#{photo.id}.jpg")
+
       {
-        photo: photo,
+        photo:,
       }
     end
   end


### PR DESCRIPTION
- 写真を作成する前にユーザ認証チェックを追加
- コンテキストからcurrent_userを使用してログインユーザと写真を関連付ける
- ユーザが認証されていない場合にGraphQLエラーを発生させるようにした